### PR TITLE
fix: consistent handling of nil passed to any wrapping function

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ func Foo() error {
 
 ### Adding stack trace
 If you are interested in adding information about the line and filename where the sentinel error happened, you can do the following:
+
+**NOTE**: While the `WithStack` will return `nil` if passed `err` equals `nil`, we do not consider this good practice and recommend checking the `err` value before invocation.
 ```go
 func Foo() error {
     ...
@@ -47,6 +49,8 @@ func Bar() error {
 
 ### Adding error cause information
 Sometimes you might be interested in returning a sentinel error, but also add some cause error to it, in such cases you can do the following:
+
+**NOTE**: While the `WithCause` will return `nil` if passed `err` equals `nil`, we do not consider this good practice and recommend checking the `err` value before invocation.
 ```go
 func FetchSomething(ID string) error {
     err := doSomething() // Here we have an error 
@@ -74,6 +78,8 @@ func FooBar() error {
 
 ### Wrapping an error with a high-level message
 Sometimes you might want to add some high-level information to an error before passing it up to the invoker.
+
+**NOTE**: While the `Wrap` will return `nil` if passed `err` equals `nil`, we do not consider this good practice and recommend checking the `err` value before invocation. 
 ```go
 func LoadProfile() error {
     err := makeAnApiCall()

--- a/errors.go
+++ b/errors.go
@@ -44,6 +44,10 @@ func New(message string, details ...any) error {
 
 // Wrap returns a new errkitError that has the given message and err as the cause.
 func Wrap(err error, message string, details ...any) error {
+	if err == nil {
+		return nil
+	}
+
 	e := newError(errors.New(message), 2, details...)
 	e.cause = err
 	return e

--- a/errors_test.go
+++ b/errors_test.go
@@ -286,6 +286,16 @@ func TestErrorsWrapping(t *testing.T) {
 		if wrappedErr != nil {
 			t.Errorf("nil expected to be returned")
 		}
+
+		wrappedErr = errkit.Wrap(nil, "Some message")
+		if wrappedErr != nil {
+			t.Errorf("nil expected to be returned")
+		}
+
+		wrappedErr = errkit.WithStack(nil)
+		if wrappedErr != nil {
+			t.Errorf("nil expected to be returned")
+		}
 	})
 }
 


### PR DESCRIPTION
Currently, the `Wrap` function required the error passed to be not nil, which was not consistent with the `WithStack` and `WithCause` functions.

This PR fixes that, and now all three functions return `nil` if `nil` is passed.